### PR TITLE
Fix printing bug where query is splay table name (dict has val type -11)

### DIFF
--- a/lib/c.coffee
+++ b/lib/c.coffee
@@ -336,7 +336,7 @@ class QTable
   values: -> @dict.values()
   value: (i) -> @dict.value i
   s: -> 2 + @dict.s()
-  length: -> @dict.val.lst[0].length()
+  length: -> if @dict.val instanceof QList then @dict.val.lst[0].length() else 0
   toString: -> (if @attr is '' then '' else "`#{@attr}#")+'+' + @dict.toString()
   @r: (b) ->
     a = QConsts.attr[b.rub()-1] || ''


### PR DESCRIPTION
If querying a splay table name, q returns a flip of a dict where value is a symbol, rather than a list of lists.
Our QTable length function assumes the latter, and silently fails w/out refreshing Query Results. This has been fixed.

Sample query:  ```flip `a`b!`c```