### PR TITLE
Fix grammar for Query Results for new LanguageMode API in Atom 1.24

### DIFF
--- a/lib/exec-query-view.coffee
+++ b/lib/exec-query-view.coffee
@@ -17,9 +17,10 @@ class ResultView
     @editor.isModified = -> false
     @editor.getQDocName = -> 'qdoc..execview'
     @editor.serialize = -> null
-    grammar = atom.grammars.grammarForScopeName 'source.q'
-    grammar.maxTokensPerLine = 1000
-    @editor.setGrammar grammar if grammar
+    atom.grammars.assignLanguageMode(@editor.getBuffer(), 'source.q')
+    #grammar = atom.grammars.grammarForScopeName 'source.q'
+    #grammar.maxTokensPerLine = 1000
+    #@editor.setGrammar grammar if grammar
     # atom.workspace.textEditorRegistry.setGrammarOverride(@editor,'source.q')
     @editor.setText '========== cut line =========='
     disposable = atom.textEditors.add(@editor)


### PR DESCRIPTION
Query Results grammar setting was broken.
Fixed per suggestion here: http://blog.atom.io/2018/02/13/atom-1-24.html
Fixes #20 